### PR TITLE
Bump SqlClient 4.8.6 and JWT 6.34.0 for Dependabot alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: build
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [deps/dependabot-bumps]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '3.1.x'
+      - run: dotnet restore SyncApp/ClickSync.csproj
+      - run: dotnet build SyncApp/ClickSync.csproj --no-restore --configuration Release

--- a/SyncApp/ClickSync.csproj
+++ b/SyncApp/ClickSync.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Microsoft.Graph" Version="3.4.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
   </ItemGroup>
 
 </Project>

--- a/SyncApp/runtimeconfig.template.json
+++ b/SyncApp/runtimeconfig.template.json
@@ -3,25 +3,13 @@
     "userPrincipalNameSuffix": "@example.com",
     "sqldb_connection": "Data Source=<redacted-sql-host>; Initial Catalog=<redacted-db>;",
     "rowsPerCycle": 500,
-    "sendMailNotification": yes,
+    "sendMailNotification": true,
     "mailNotificationTo": "<redacted-email>",
     "mailNotificationFrom": "<redacted-email>",
     "debug": true,
     "disableUsers": true,
     "maxRetirements": 500,
     "maxChanges": 500,
-    "licenseGroups": "<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>",
-"<redacted-guid>"
+    "licenseGroups": "<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>,<redacted-guid>"
   }
 }


### PR DESCRIPTION
## Summary
- `System.Data.SqlClient` 4.8.5 -> 4.8.6 (Dependabot alert #4, high — SQL Data Provider Security Feature Bypass)
- `System.IdentityModel.Tokens.Jwt` 6.5.1 -> 6.34.0 (Dependabot alert #3, medium — ASP.NET Core templates DoS)
- Adds a temporary `build` workflow under `.github/workflows/build.yml` so the bumps can be validated. Will be removed in a follow-up cleanup PR after merge.
- Fixes a pre-existing malformed `SyncApp/runtimeconfig.template.json` (bare `yes` token, dangling GUID string literals after `licenseGroups`). This was a build blocker discovered after CI was added; **not** caused by the dependency bumps. Older .NET SDKs tolerated it, but the .NET 10 SDK on `ubuntu-latest` fails `GenerateRuntimeConfigurationFiles` with `JsonReaderException`.

Closes alerts #3 and #4.

## Test plan
- [x] `dotnet restore` succeeds against `SyncApp/ClickSync.csproj`
- [ ] `dotnet build --configuration Release` succeeds on netcoreapp3.1 (CI)
- [ ] Dependabot alerts #3 and #4 auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)